### PR TITLE
TPC-H: fixing scripts for CI run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ $(TNT_DB): | $(TABLE_FILES)
 
 # run benchmarks
 bench-sqlite: $(SQLITE_DB)
-	./bench_queries.sh | tee bench-sqlite.log
+	./bench_queries.sh 2>&1 | tee bench-sqlite.log
 
 bench-tnt: $(TNT_DB)
-	$(TARANTOOL) execute_query.lua -n 3 | tee bench-tnt.log
+	$(TARANTOOL) execute_query.lua -n 3 2>&1 | tee bench-tnt.log
 
 report:
 	perl ./report.pl bench-sqlite.log > bench-sqlite.csv

--- a/bench_queries.sh
+++ b/bench_queries.sh
@@ -8,9 +8,8 @@ function check_q {
 	)
 }
 
-# we need to execute all from 1 to 22
-for i in `seq 1 22`; do
-	check_q $i
+# we need to execute all from 1 to 22 (except 13, 17, 20 and 22 in CI)
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 14 15 16 18 19 21; do
 	check_q $i
 	check_q $i
 	check_q $i

--- a/execute_query.lua
+++ b/execute_query.lua
@@ -91,6 +91,7 @@ local function bench(func)
 end
 
 local function single_query(q)
+    local t_ = nil
     local qname = string.format("queries/%s.sql", q)
     print(qname)
     t_ = bench(
@@ -143,7 +144,7 @@ for opt, arg in getopt(arg, 'q:n:p:m:yv', nonoptions) do
     end
 end
 
-config(portN, mem_size)
+config(port, mem_size)
 
 -- if no query selected - process all queries
 if queryN == nil then


### PR DESCRIPTION
- exclude long running SQL bench queries 13, 17, 20 and 22
- fixed variable definition in execute_query.lua
- run SQL bench queries 3 times instead of 4