### PR TITLE
TPC-H: adding 'explain' mode for the TPC-H queries 

### DIFF
--- a/execute_query.lua
+++ b/execute_query.lua
@@ -51,14 +51,12 @@ local function sql_stmts(qname)
 end
 
 local nIndents = {
-    ['Next'] = -2, ['Prev'] = -2,
-    ['VPrev'] = -2, ['VNext'] = -2,
-    ['SorterNext'] = -2,
-    ['SorterSort'] = 2,
-    ['InitCoroutine'] = 2, ['EndCoroutine'] = -2,
-    ['SeekGE'] = 2, ['SeekGT'] = 2, ['SeekLT'] = 2,
-    ['Rewind'] = 2, ['RowSetRead'] = 2,
-
+    Next = -2, Prev = -2,
+    VPrev = -2, VNext = -2,
+    SorterNext = -2, SorterSort = 2,
+    InitCoroutine = 2, EndCoroutine = -2,
+    SeekGE = 2, SeekGT = 2, SeekLT = 2,
+    Rewind = 2, RowSetRead = 2,
 }
 -- local azYield = { "Yield", "SeekLT", "SeekGT", "RowSetRead", "Rewind" }
 -- local azGoto = { "Goto" }


### PR DESCRIPTION
We are adding `-e` (explain) option to the `execute_query.lua` driver. Now if we want to see tthe query plan for the Tarantool running query number N we need to replace `-q` (execute given query) with `-e` option. 

And furthermore, the query plan will be shown in fancy, SQLite like way, with indents and such, e.g.:

```
tsafin@M1BOOK6319:~/docs/GitHub/sqlite_tpch$ $TARANTOOL ./execute_query.lua -e 2 -n1
2020-06-12 00:54:51.661 [23102] main/103/execute_query.lua C> Tarantool 2.4.0-253-g2631ec289
2020-06-12 00:54:51.661 [23102] main/103/execute_query.lua C> log level 5
...
2020-06-12 00:54:51.837 [23102] main/103/execute_query.lua I> 0.1M rows processed
2020-06-12 00:54:51.976 [23102] main/103/execute_query.lua I> 0.2M rows processed
2020-06-12 00:54:52.142 [23102] main/103/execute_query.lua I> 0.3M rows processed
2020-06-12 00:54:52.301 [23102] main/103/execute_query.lua I> 0.4M rows processed
2020-06-12 00:54:52.380 [23102] main/103/execute_query.lua I> recover from `./00000000000000432877.xlog'
2020-06-12 00:54:52.381 [23102] main/103/execute_query.lua I> done `./00000000000000432877.xlog'
2020-06-12 00:54:52.394 [23102] main/103/execute_query.lua I> ready to accept requests
2020-06-12 00:54:52.394 [23102] main/103/execute_query.lua C> leaving orphan mode
2020-06-12 00:54:52.394 [23102] main/105/checkpoint_daemon I> scheduled next checkpoint for Fri Jun 12 02:12:03 2020
2020-06-12 00:54:52.394 [23102] main/103/execute_query.lua I> set 'memtx_memory' configuration option to 10737418240
2020-06-12 00:54:52.395 [23102] main/103/execute_query.lua I> set 'listen' configuration option to "3301"
queries/2.sql
.
addr opcode        p1   p2   p3   p4            p5 comment
-----------------------------------------------------------------
0    Init          0    127  0                  00 Start at 127
1    OpenTEphemeral1    9    0    k(4,B,B,B,B)  00
2    IteratorOpen  9    0    1                  00 index id = 0, space ptr =  or reg[1]; Sort table
3    Integer       100  2    0                  00 r[2]=100
4    MustBeInt     2    7    0                  00
5    Integer       0    3    0                  00 r[3]=0
6    Ge            3    9    2                  00 if r[2]>=r[3] goto 9
7    SetDiag       159  0    0    Failed to execute SQL statement: Only positive integers are allowed in the LIMIT clause00
8    Halt          -1   0    0                  00 LIMIT counter
9    Eq            3    126  2                  00 if r[2]==r[3] goto 126
10   IteratorOpen  10   0    0    space<name=PARTSUPP>00 index id = 0, space ptr = space<name=PARTSUPP> or reg[0]; pk_unnamed_PARTSUPP_1
11   IteratorOpen  11   0    0    space<name=SUPPLIER>02 index id = 0, space ptr = space<name=SUPPLIER> or reg[0]; pk_unnamed_SUPPLIER_1
12   IteratorOpen  12   0    0    space<name=PART>02 index id = 0, space ptr = space<name=PART> or reg[0]; pk_unnamed_PART_1
13   IteratorOpen  13   0    0    space<name=NATION>02 index id = 0, space ptr = space<name=NATION> or reg[0]; pk_unnamed_NATION_1
14   IteratorOpen  14   0    0    space<name=REGION>02 index id = 0, space ptr = space<name=REGION> or reg[0]; pk_unnamed_REGION_1
15   Rewind        10   115  4    0             00
16     Column        10   1    4                  00 r[4]=
17     IsNull        4    19   0                  00 if r[4]==NULL goto 19
18     MustBeInt     4    114  0                  00
19     SeekGE        11   114  4    1             00 key=r[4]
20       IdxGT         11   114  4    1             00 key=r[4]
21       Column        10   0    5                  00 r[5]=
22       IsNull        5    24   0                  00 if r[5]==NULL goto 24
23       MustBeInt     5    113  0                  00
```
