### PR TITLE
tpch: enable 13, 17 and 20 tests

### DIFF
--- a/execute_query.lua
+++ b/execute_query.lua
@@ -13,8 +13,7 @@ local explain = false
 local port = 3301
 local mem_size = 10 * 1024^3
 
--- FIXME -- Q13 is 4h50mins long, Q17 - 48mins, and Q20 - 1h11mins
-local excluded_tests = {13, 17, 20}
+local excluded_tests = {}
 
 io.stdout:setvbuf 'no'
 


### PR DESCRIPTION
Since issue tarantool/tarantool#4933 was closed there is no reason to
keep these tests disabled.